### PR TITLE
escaping non utf8 chars on input

### DIFF
--- a/src/Http/Controllers/AutocompleteController.php
+++ b/src/Http/Controllers/AutocompleteController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Str;
 use Wingly\GooglePlaces\GooglePlaces;
 use Wingly\GooglePlaces\Pipes\Country;
 use Wingly\GooglePlaces\Pipes\Language;
@@ -16,7 +17,7 @@ class AutocompleteController extends Controller
     public function __invoke(Request $request): JsonResponse
     {
         $results = app(Pipeline::class)
-            ->send(GooglePlaces::autocomplete($request->query('input') ?? ''))
+            ->send(GooglePlaces::autocomplete(Str::ascii($request->query('input')) ?? ''))
             ->through([Language::class, Country::class, Types::class])
             ->thenReturn()
             ->get();

--- a/src/Http/Controllers/GeocodeController.php
+++ b/src/Http/Controllers/GeocodeController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Str;
 use Wingly\GooglePlaces\GooglePlaces;
 use Wingly\GooglePlaces\Pipes\Country;
 use Wingly\GooglePlaces\Pipes\Language;
@@ -15,7 +16,7 @@ class GeocodeController extends Controller
     public function __invoke(Request $request): JsonResponse
     {
         $results = app(Pipeline::class)
-            ->send(GooglePlaces::geocode($request->query('input') ?? ''))
+            ->send(GooglePlaces::geocode(Str::ascii($request->query('input')) ?? ''))
             ->through([Language::class, Country::class])
             ->thenReturn()
             ->get();

--- a/tests/AutocompleteControllerTest.php
+++ b/tests/AutocompleteControllerTest.php
@@ -25,6 +25,20 @@ class AutocompleteControllerTest extends TestCase
         $this->assertEquals([], $response->json());
     }
 
+    public function test_it_escapes_non_utf8_chars_in_the_input()
+    {
+        $response = $this->getJson('/autocomplete?input=paris%C2%B4%08');
+
+        $response->assertOk();
+
+        $response->assertOk();
+        $this->assertIsArray($response->json());
+
+        $prediction = $response->json()[0];
+
+        $this->assertArrayHasKey('name', $prediction);
+    }
+
     public function test_it_returns_empty_array_when_called_without_input()
     {
         $response = $this->getJson('/autocomplete');

--- a/tests/GeocodeControllerTest.php
+++ b/tests/GeocodeControllerTest.php
@@ -25,6 +25,18 @@ class GeocodeControllerTest extends TestCase
         $this->assertEquals([], $response->json());
     }
 
+    public function test_it_escapes_non_utf8_chars_in_the_input()
+    {
+        $response = $this->getJson('/geocode?input=Antwerp%C2%B4%08');
+
+        $response->assertOk();
+
+        $this->assertIsArray($response->json());
+
+        $this->assertArrayHasKey('lat', $response->json());
+        $this->assertArrayHasKey('lng', $response->json());
+    }
+
     public function test_it_returns_empty_array_when_called_without_input()
     {
         $response = $this->getJson('/geocode');


### PR DESCRIPTION
hello,
in order to avoid the 400 Bad Request response from google API when the input contains a non-utf8 or non-ascci char. I escaped them from the input in the HTTP layer.